### PR TITLE
Bump spigot-api from 1.19.2-R0.1-SNAPSHOT to 1.19.3-R0.1-SNAPSHOT

### DIFF
--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation('space.rocketplugins.pluginslib:bukkit:2.0.3.2') {
         exclude module: 'slimjar'
     }
-    compileOnly 'org.spigotmc:spigot-api:1.19.2-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.19.3-R0.1-SNAPSHOT'
     compileOnly 'me.clip:placeholderapi:2.11.2'
     implementation 'net.kyori:adventure-api:4.12.0'
 }


### PR DESCRIPTION
Bumps spigot-api from 1.19.2-R0.1-SNAPSHOT to 1.19.3-R0.1-SNAPSHOT.

---
updated-dependencies:
- dependency-name: org.spigotmc:spigot-api dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>